### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Michael Stal
 sentence=Library to use three LEDs as a binary dice.
 paragraph=
 category=Sensors
-url=www.stal.de
+url=http://www.stal.de
 architectures=*
 


### PR DESCRIPTION
The library.properties url property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.